### PR TITLE
BUG: Admin token used instead of generated approle tokens

### DIFF
--- a/scripts/events.sh
+++ b/scripts/events.sh
@@ -9,10 +9,10 @@ echo "generating audit events..."
 export VAULT_ADDR=http://localhost:8200
 export VAULT_TOKEN=$(jq -r .root_token init.json)
 
-# vault auth enable userpass > /dev/null
-# vault auth enable approle > /dev/null
-# vault secrets enable -version=2 kv > /dev/null
-# vault secrets enable database > /dev/null
+vault auth enable userpass > /dev/null || true
+vault auth enable approle > /dev/null || true
+vault secrets enable -version=2 kv > /dev/null || true
+vault secrets enable database > /dev/null || true
 
 for i in {1..20}; do
   vault write auth/userpass/users/$i password=$i > /dev/null
@@ -21,7 +21,6 @@ done
 
 for i in {1..20}; do
   unset VAULT_TOKEN
-  export VAULT_TOKEN=$(vault login -method=userpass -token-only username=$i password=$i > /dev/null 2>&1)
   vault login -method=userpass username=$i password=$i > /dev/null 2>&1
 
   r=$(vault read -field=role_id auth/approle/role/$i/role-id)
@@ -30,7 +29,6 @@ for i in {1..20}; do
 
   vault kv put kv/$i/db db_user=$RANDOM db_password=$RANDOM > /dev/null
   vault kv list kv/$i > /dev/null
-  vault kv put kv/$i/db db_user=$RANDOM db_password=$RANDOM > /dev/null
   vault kv get kv/$i/db > /dev/null
   vault kv metadata delete kv/$i/db > /dev/null
 done

--- a/scripts/events.sh
+++ b/scripts/events.sh
@@ -9,10 +9,10 @@ echo "generating audit events..."
 export VAULT_ADDR=http://localhost:8200
 export VAULT_TOKEN=$(jq -r .root_token init.json)
 
-vault auth enable userpass > /dev/null
-vault auth enable approle > /dev/null
-vault secrets enable -version=2 kv > /dev/null
-vault secrets enable database > /dev/null
+# vault auth enable userpass > /dev/null
+# vault auth enable approle > /dev/null
+# vault secrets enable -version=2 kv > /dev/null
+# vault secrets enable database > /dev/null
 
 for i in {1..20}; do
   vault write auth/userpass/users/$i password=$i > /dev/null
@@ -20,14 +20,17 @@ for i in {1..20}; do
 done
 
 for i in {1..20}; do
-  vault login -method=userpass -no-store username=$i password=$i > /dev/null 2>&1
+  unset VAULT_TOKEN
+  export VAULT_TOKEN=$(vault login -method=userpass -token-only username=$i password=$i > /dev/null 2>&1)
+  vault login -method=userpass username=$i password=$i > /dev/null 2>&1
 
   r=$(vault read -field=role_id auth/approle/role/$i/role-id)
   s=$(vault write -f -field=secret_id auth/approle/role/$i/secret-id)
   vault write auth/approle/login role_id=$r secret_id=$s > /dev/null
-  
+
   vault kv put kv/$i/db db_user=$RANDOM db_password=$RANDOM > /dev/null
   vault kv list kv/$i > /dev/null
+  vault kv put kv/$i/db db_user=$RANDOM db_password=$RANDOM > /dev/null
   vault kv get kv/$i/db > /dev/null
   vault kv metadata delete kv/$i/db > /dev/null
 done


### PR DESCRIPTION
Description:
I expected different tokens and accessors to appear in the audit log. However, only the HMACed root token was showing up.
Updated to unset the `VAULT_TOKEN` env variable and actually login as the specific app role.
Screenshot from Elastic, after the token is unset and `vault login` has run.

<img width="1688" alt="Screenshot 2024-07-10 at 09 23 01" src="https://github.com/michaelkosir/vault-audit-logs/assets/5985957/b3cf066e-7166-4b1a-bf0f-685a0e1b026e">

Thanks so much for publishing this demo! Super useful. 👍 